### PR TITLE
add path of source into name of backup file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,25 @@
-# Timestamp Backup LibreOffice extension
+# Timestamp Backup LibreOffice Extension
 
-This extension created for the LibreOffice and OpenOffice enables the 
-user to make normal Save and to create a TimeStamped Backup copy of the 
-actual document at once. 
-The archiv file with a time stamped filename will placed into the 
-Backup directory given in the 
-Tools - Options - Open/LibreOffice - Paths
-It is better to adjust the path of the Backup directory to a user 
+This extension for LibreOffice and OpenOffice enables the 
+user to make a normal save and to additionally create a timestamped backup copy of the 
+document with just one click.
+
+The backup copy will be placed into the 
+backup directory set in `Tools - Options - Open/LibreOffice - Paths - Backups`
+
+It is recommended to adjust the path of the backup directory to a user 
 friendly place.
 
-The extension has a menu item in the File menu, and a toolbar icon 
-in the Standard toolbar, and it works in the applications listed below:
-Writer, WriterWeb, WriterMaster; Calc, Draw, Impress, Math applications.
+The extension has a menu item in the `File` menu, and a toolbar icon 
+in the `standard` toolbar.
+
+It works in these applications: Writer, WriterWeb, WriterMaster, Calc, Draw, Impress, Math.
 
 You can download the latest version of this extension for LibreOffice 
-and for OpenOffice from the page:
+and for OpenOffice from this page:
 http://flowcont.hu/LO_oxt_store/
 
-This extension under licenced in the GPL v3 licence.
+License: GPL v3
 
 Original creator: Kovács Tibor
 

--- a/timeStampBackup/Addons.xcu
+++ b/timeStampBackup/Addons.xcu
@@ -18,7 +18,7 @@
             <prop oor:name="Title" oor:type="xs:string">
               <value xml:lang="en">Save and Timestamp-backup</value>
               <value xml:lang="hu">Mentés és időbélyeges archiválás</value>
-              <value xml:lang="de">Speichern und Zeitstempelspeichern</value> 
+              <value xml:lang="de">Speichern, auch als Backup mit Zeitstempel</value> 
               <value xml:lang="it">Salva e archivio con date e ora</value> 
               <value xml:lang="es">Guardar y archivar con fecha y hora</value>
               <value xml:lang="ru">Сохранение и архив с указанием даты и времени</value>             
@@ -64,7 +64,7 @@
             <prop oor:name="Title" oor:type="xs:string">
               <value xml:lang="en">Save and Timestamp-backup</value>
               <value xml:lang="hu">Mentés és időbélyeges archiválás</value>
-              <value xml:lang="de">Speichern und Zeitstempelspeichern</value>
+              <value xml:lang="de">Speichern, auch als Backup mit Zeitstempel</value>
               <value xml:lang="it">Salva e archivio con date e ora</value> 
               <value xml:lang="es">Guardar y archivar con fecha y hora</value>
               <value xml:lang="ru">Сохранение и архив с указанием даты и времени</value>
@@ -103,7 +103,7 @@
             <prop oor:name="Title" oor:type="xs:string">
               <value xml:lang="en">Save and Timestamp-backup</value>
               <value xml:lang="hu">Mentés és időbélyeges archiválás</value>
-              <value xml:lang="de">Speichern und Zeitstempelspeichern</value>
+              <value xml:lang="de">Speichern, auch als Backup mit Zeitstempel</value>
               <value xml:lang="it">Salva e archivio con date e ora</value> 
               <value xml:lang="es">Guardar y archivar con fecha y hora</value>
               <value xml:lang="ru">Сохранение и архив с указанием даты и времени</value>

--- a/timeStampBackup/pkg-desc/pkg-description.de
+++ b/timeStampBackup/pkg-desc/pkg-description.de
@@ -1,14 +1,19 @@
-Diese Erweiterung wurde für LibreOffice und OpenOffice erstellt und ermöglicht es den Benutzern, normale Save zu erstellen und eine TimeStamped Backup-Kopie des aktuellen Dokuments auf einmal zu erstellen.
-Die Archivdatei mit einem zeitgestempelten Dateinamen wird in das Backup-Verzeichnis in den Tools - Optionen - Open / LibreOffice - Pfade platziert
-Es ist besser, den Pfad des Backup-Verzeichnisses an einen benutzerfreundlichen Ort anzupassen.
+Diese Erweiterung wurde für LibreOffice und OpenOffice erstellt und ermöglicht es dem Benutzer, 
+gleichzeitig die Datei zu speichern und eine Backup-Kopie mit Zeitspempel zu erstellen. 
 
-Die Erweiterung verfügt über einen Menüpunkt im Menü Datei und ein Symbolleistensymbol in der Symbolleiste Standard, und es funktioniert in den folgenden Anwendungen:
-Writer, WriterWeb, WriterMaster; Calc, Draw, Impress, Base, Mathematische Anwendungen.
+Diese Backup-Kopie wird in das unter Extras - Optionen - Open-/LibreOffice - Pfade - Backup
+eingestellte Verzeichnis gespeichert. Es wird empfohlen, das Backup-Verzeichnis auf einen
+benutzerfreundlicheren Ort umzustellen.
 
-Sie können die neueste Version dieser Erweiterung für LibreOffice herunterladen
-Und für OpenOffice von der Seite:
+Die Erweiterung fügt einen Eintrag im Menü Datei und ein Symbol in der Symbolleiste Standard hinzu.
+
+Die Erweiterung funktioniert in den folgenden Anwendungen:
+Writer, WriterWeb, WriterMaster; Calc, Draw, Impress, Base, Math
+
+Sie können die neueste Version dieser Erweiterung für LibreOffice und OpenOffice 
+von dieser Seite herunterladen:
 Http://flowcont.hu/LO_oxt_store/
 
-Diese Erweiterung lizenziert unter der GPL v3 Lizenz.
+Diese Erweiterung ist lizenziert unter der GPL v3.
 
 Tibor Kovács - Flow-Cont Ltd.

--- a/timeStampBackup/pkg-desc/pkg-description.en
+++ b/timeStampBackup/pkg-desc/pkg-description.en
@@ -1,14 +1,19 @@
-This extension was created for the LibreOffice and OpenOffice and it enables the users to make normal Save and to create a TimeStamped Backup copy of the actual document at once. 
-The archive file with a time stamped filename will placed into the Backup directory given in the Tools - Options - Open/LibreOffice - Paths
-It is better to adjust the path of the Backup directory to a user friendly place.
+This extension for LibreOffice and OpenOffice enables the user to make a normal save and to additionally create a timestamped backup copy of the document with just one click.
 
-The extension has a menu item in the File menu, and a toolbar icon in the Standard toolbar, and it works in the applications listed below:
-Writer, WriterWeb, WriterMaster; Calc, Draw, Impress, Base, Math applications.
+The backup copy will be placed into the backup directory set in Tools - Options - Open/LibreOffice - Paths - Backups
 
-You can download the latest version of this extension for LibreOffice 
-and for OpenOffice from the page:
-http://flowcont.hu/LO_oxt_store/
+It is recommended to adjust the path of the backup directory to a user friendly place.
 
-This extension licenced under  the GPL v3 licence.
+The extension has a menu item in the File menu, and a toolbar icon in the standard toolbar.
 
-Tibor Kovács - Flow-Cont Ltd.
+It works in these applications: Writer, WriterWeb, WriterMaster, Calc, Draw, Impress, Math.
+
+You can download the latest version of this extension for LibreOffice and for OpenOffice from this page: http://flowcont.hu/LO_oxt_store/
+
+License: GPL v3
+
+Original creator: Kovács Tibor
+
+Project maintainer: kovlev, however any contribution is appreciated
+
+Relevant OOo forum thread: https://forum.openoffice.org/en/forum/viewtopic.php?f=47&t=86742

--- a/timeStampBackup/timeStampBackup/timeStampBackup.xba
+++ b/timeStampBackup/timeStampBackup/timeStampBackup.xba
@@ -30,17 +30,20 @@ Sub timeStampBackup
  Dim sTimeStamp as string
  Dim sLocale as string
  Dim oDoc as object
+ Dim dirname as string
  
 	If (Not GlobalScope.BasicLibraries.isLibraryLoaded(&quot;Tools&quot;)) Then
 		GlobalScope.BasicLibraries.LoadLibrary(&quot;Tools&quot;)
 	End If
-	sTimeStamp = &quot;_&quot; &amp; Format(Year(Now), &quot;0000&quot;) &amp; Format(Month(Now), &quot;00&quot;) &amp; Format(Day(Now), &quot;00&quot;) &amp; &quot;_&quot; &amp; _
+	sTimeStamp = &quot;___&quot; &amp; Format(Year(Now), &quot;0000&quot;) &amp; Format(Month(Now), &quot;00&quot;) &amp; Format(Day(Now), &quot;00&quot;) &amp; &quot;_&quot; &amp; _
                        Format(Hour(Now), &quot;00&quot;) &amp; Format(Minute(Now), &quot;00&quot;) &amp; Format(Second(Now), &quot;00&quot;)
 	oDoc = Thiscomponent	
 	
 	If oDoc.hasLocation() then
 		sDocURL = oDoc.getURL()
+		dirname=ReplaceString(DirectoryNameoutofPath(sDocURL, &quot;/&quot;),&quot;_&quot;,&quot;:&quot;)
 		sBackupURL = CreateUnoService(&quot;com.sun.star.util.PathSettings&quot;).Backup &amp; &quot;/&quot; &amp; _
+		ReplaceString(RIGHT(dirname,LEN(dirname)-8),&quot;_&quot;,&quot;/&quot;) &amp; &quot;___&quot; &amp; _
 		GetFileNameWithoutExtension(sDocURL, &quot;/&quot;) &amp; _
 		sTimeStamp() &amp; &quot;.&quot; &amp; _
 		GetFileNameExtension(sDocURL, &quot;/&quot;)		

--- a/timeStampBackup/timeStampBackup/timeStampBackup.xba
+++ b/timeStampBackup/timeStampBackup/timeStampBackup.xba
@@ -40,7 +40,9 @@ Sub timeStampBackup
 	
 	If oDoc.hasLocation() then
 		sDocURL = oDoc.getURL()
+		dirname=DirectoryNameoutofPath(sDocURL, &quot;/&quot;)
 		sBackupURL = CreateUnoService(&quot;com.sun.star.util.PathSettings&quot;).Backup &amp; &quot;/&quot; &amp; _
+		ReplaceString(RIGHT(dirname,LEN(dirname)-8),&quot;_&quot;,&quot;/&quot;) &amp; &quot;___&quot; &amp; _   
 		GetFileNameWithoutExtension(sDocURL, &quot;/&quot;) &amp; _
 		sTimeStamp() &amp; &quot;.&quot; &amp; _
 		GetFileNameExtension(sDocURL, &quot;/&quot;)		

--- a/timeStampBackup/timeStampBackup/timeStampBackup.xba
+++ b/timeStampBackup/timeStampBackup/timeStampBackup.xba
@@ -50,11 +50,11 @@ Sub timeStampBackup
 		sLocale = GetRegistryKeyContent(&quot;org.openoffice.Setup/L10N&quot;,FALSE).getByName(&quot;ooLocale&quot;)
 		Select case sLocale
 			case &quot;en-GB&quot;, &quot;en-US&quot;
-				MsgBox(&quot;The document have not any URL (have not a valid file name and / or path) yet.&quot; &amp; Chr(10) &amp; &quot;The document will not be archived. Save your document first.&quot;,16,&quot;Attention:&quot;)
+				MsgBox(&quot;The document has not any URL (has not a valid file name and / or path) yet.&quot; &amp; Chr(10) &amp; &quot;The document will not be archived. Save your document first.&quot;,16,&quot;Attention:&quot;)
 			case &quot;hu&quot;
 				MsgBox(&quot;A dokumentum még nem rendelkezik fájlnévvel és/vagy elérési útvonallal!&quot; &amp; Chr(10) &amp; &quot;Az archiválás nem végrahajtható. Előbb mentsd el a dokumentumot!&quot;,16,&quot;Figyelem:&quot;)
 			case &quot;de&quot;
-				MsgBox(&quot;Das Dokument haben keine URL (keine gültige Dateinamen und / oder Pfad) noch.&quot; &amp; Chr(10) &amp; &quot;Das Dokument wird nicht archiviert. Speichern Sie zuerst das Dokument.&quot;,16,&quot;Achtung:&quot;)
+				MsgBox(&quot;Das Dokument hat noch keine URL (keinen gültigen Dateinamen und / oder Pfad).&quot; &amp; Chr(10) &amp; &quot;Das Dokument wird nicht archiviert. Speichern Sie zuerst das Dokument.&quot;,16,&quot;Achtung:&quot;)
 			case &quot;it&quot;
 				MsgBox(&quot;Il documento non ha alcun URL (non hanno un nome valido di file e / o percorso) ancora.&quot; &amp; Chr(10) &amp; &quot;Il documento non verrà archiviato. Salvare il documento prima.&quot;,16,&quot;Attenzione:&quot;)
 			case &quot;es&quot;


### PR DESCRIPTION
with this patch `C:\Users\username\Desktop\test.odt` should be saved with this name: `C__Users_username_Desktop___test___20180325_213617.odt`

my motivation: I have a folder per project/client. My filenames are quite often only the current date. I often write multiple letters/documents per day. With your current implementation it was difficult to distinguish the source files for each backup file. 

I don't know how useful this is to other people. I opened this pull request in case you consider this to be of general interest. 

additional info: 
- I use `dirname=ReplaceString(...` to remove `:` from paths in windows. 
- Tested on win10 and linux

