### PR TITLE
Keep password protections in backup files.

### DIFF
--- a/timeStampBackup/timeStampBackup/timeStampBackup.xba
+++ b/timeStampBackup/timeStampBackup/timeStampBackup.xba
@@ -40,15 +40,10 @@ Sub timeStampBackup
                        Format(Hour(Now), &quot;00&quot;) &amp; Format(Minute(Now), &quot;00&quot;) &amp; Format(Second(Now), &quot;00&quot;)
 	oDoc = Thiscomponent	
 	
-	If oDoc.hasLocation() then
-		&apos;Regular save
-      	oDoc.store()
-    else
-    	&apos;Pop up a save as dialog
-      	document   = ThisComponent.CurrentController.Frame
-      	dispatcher = createUnoService(&quot;com.sun.star.frame.DispatchHelper&quot;)
-      	dispatcher.executeDispatch(document, &quot;.uno:Save&quot;, &quot;&quot;, 0, Array())
-    end if
+   	&apos;internal save command
+   	document   = ThisComponent.CurrentController.Frame
+   	dispatcher = createUnoService(&quot;com.sun.star.frame.DispatchHelper&quot;)
+   	dispatcher.executeDispatch(document, &quot;.uno:Save&quot;, &quot;&quot;, 0, Array())
     
     If oDoc.hasLocation() then
     	&apos;In case the file save was unsuccessful
@@ -57,7 +52,7 @@ Sub timeStampBackup
    		GetFileNameWithoutExtension(sDocURL, &quot;/&quot;) &amp; _
    		sTimeStamp() &amp; &quot;.&quot; &amp; _
    		GetFileNameExtension(sDocURL, &quot;/&quot;)      
-   		oDoc.storeToURL(sBackupURL, array()) 
+   		FileCopy oDoc.URL, sBackupURL
    	end if
 	
 End sub


### PR DESCRIPTION
If used from a password protected document, timeStampBackup creates unprotected copies, which is probably not what the user expects.
Replacing the call to "storeToURL" by a simple file copy does the job. If I'm right, that's how the internal automatic backup works.

While I'm at it, the ".uno:Save" dispatcher command acts like "store()" when a location exists. So the first location check is not needed.

Thanks for your comments.